### PR TITLE
Vesting whitelist

### DIFF
--- a/contracts-upgradeable/mock/MockVestedTokenUpgradeable.sol
+++ b/contracts-upgradeable/mock/MockVestedTokenUpgradeable.sol
@@ -19,4 +19,8 @@ contract MockVestedTokenUpgradeable is VestedTokenUpgradeable, OwnableUpgradeabl
     ) external onlyOwner {
         _setupSchedule(cliff, cliffAmount, duration, vestingAdmin);
     }
+
+    function whitelistRecipient(address recipient) external onlyOwner {
+        recipientWhitelist[recipient] = true;
+    }
 }

--- a/contracts-upgradeable/vesting/VestedTokenUpgradeable.sol
+++ b/contracts-upgradeable/vesting/VestedTokenUpgradeable.sol
@@ -20,6 +20,7 @@ abstract contract VestedTokenUpgradeable is IVestedToken, ERC20Upgradeable {
     mapping(uint256 => VestingPeriod) public override vestingPeriods;
     mapping(address => VestedBalance) public override vestedBalances;
     mapping(address => uint256) public vestingAdmins;
+    mapping(address => bool) public recipientWhitelist;
 
     function lockedTokens(address account) public view virtual returns (uint256) {
         VestedBalance storage vestingBalance = vestedBalances[account];
@@ -66,9 +67,11 @@ abstract contract VestedTokenUpgradeable is IVestedToken, ERC20Upgradeable {
             vestingBalance.amount = amount;
             emit TokensVested(id, to, amount);
         } else {
-            require(balanceOf(from) >= lockedTokens(from), "TOKENS_VESTED");
+            if (!recipientWhitelist[to]) {
+                require(balanceOf(from) >= lockedTokens(from), "TOKENS_VESTED");
+            }
         }
     }
 
-    uint256[50] private __gap;
+    uint256[49] private __gap;
 }

--- a/contracts/mock/MockVestedToken.sol
+++ b/contracts/mock/MockVestedToken.sol
@@ -17,4 +17,8 @@ contract MockVestedToken is VestedToken, Ownable {
     ) external onlyOwner {
         _setupSchedule(cliff, cliffAmount, duration, vestingAdmin);
     }
+
+    function whitelistRecipient(address recipient) external onlyOwner {
+        recipientWhitelist[recipient] = true;
+    }
 }

--- a/contracts/vesting/VestedToken.sol
+++ b/contracts/vesting/VestedToken.sol
@@ -20,6 +20,7 @@ abstract contract VestedToken is IVestedToken, ERC20 {
     mapping(uint256 => VestingPeriod) public override vestingPeriods;
     mapping(address => VestedBalance) public override vestedBalances;
     mapping(address => uint256) public vestingAdmins;
+    mapping(address => bool) public recipientWhitelist;
 
     function lockedTokens(address account) public view virtual returns (uint256) {
         VestedBalance storage vestingBalance = vestedBalances[account];
@@ -66,7 +67,9 @@ abstract contract VestedToken is IVestedToken, ERC20 {
             vestingBalance.amount = amount;
             emit TokensVested(id, to, amount);
         } else {
-            require(balanceOf(from) >= lockedTokens(from), "TOKENS_VESTED");
+            if (!recipientWhitelist[to]) {
+                require(balanceOf(from) >= lockedTokens(from), "TOKENS_VESTED");
+            }
         }
     }
 }


### PR DESCRIPTION
In some scenarios it might be useful to be able to transfer vested tokens to certain addresses ignoring the vesting schedule (e.g., depositing vested tokens into a governance contract). When the tokens are returned to the wallet, the tokens continue to be vested.